### PR TITLE
Add isInstant to the closeOptionButtons

### DIFF
--- a/js/angular/controller/listController.js
+++ b/js/angular/controller/listController.js
@@ -113,7 +113,7 @@ function($scope, $attrs, $ionicListDelegate, $ionicHistory) {
     return isSwipeable;
   };
 
-  self.closeOptionButtons = function() {
-    self.listView && self.listView.clearDragEffects();
+  self.closeOptionButtons = function(isInstant) {
+    self.listView && self.listView.clearDragEffects(isInstant);
   };
 }]);


### PR DESCRIPTION
Sometimes it would be nice to be able to have the buttons close instantly. This exposes the underlying listView's ability to do that.